### PR TITLE
Map GreyNoise results to Splunk CIM

### DIFF
--- a/APP_FILES_ONLY/SA-GreyNoise/bin/event_generator.py
+++ b/APP_FILES_ONLY/SA-GreyNoise/bin/event_generator.py
@@ -1,4 +1,5 @@
 """This file helps custom commands generate events by passing simple API responses to it."""
+
 import threading  # noqa # pylint: disable=unused-import
 import time
 import traceback
@@ -15,6 +16,7 @@ from utility import (
     get_caching,
     get_dict,
     get_ips_not_in_cache,
+    map_fields_to_cim,
     nested_dict_iter,
 )
 
@@ -310,7 +312,7 @@ def event_processor(records_dict, result, method, field_name, logger):
     # This will either have API response for the chunk or
     # the exception message denoting exception occurred while fetching the data
     if result["response"]:
-        if type(result["response"][0]) == list:
+        if isinstance(result["response"][0], list):
             api_results = []
             for each in result["response"][0]:
                 api_results.append(each)
@@ -339,7 +341,7 @@ def event_processor(records_dict, result, method, field_name, logger):
         if error_flag:
             # Exception has occurred while fetching the data
             if field_name in record and record[field_name]:
-                event = {"ip": record[ip_field], "error": api_results}
+                event = {"ip": record[field_name], "error": api_results}
                 yield make_invalid_event(method, event, True, record)
             else:
                 # Either the record is not having IP field or the value of the IP field is ''
@@ -399,6 +401,8 @@ def make_valid_event(method, data, first_event=False, record=None):
             # so that Splunk can get the values of the fields from it
             results = nested_dict_iter(data)
 
+        results.update(map_fields_to_cim(results))
+
         results["source"] = "greynoise"
         results["sourcetype"] = "greynoise"
         results["_time"] = time.time()
@@ -408,7 +412,9 @@ def make_valid_event(method, data, first_event=False, record=None):
     else:
         # Irrespective of first_record_flag, we will always retrieve the default dictionary for the generating commands
         results = dict(get_dict(method))
-        results.update(nested_dict_iter(data, prefix="greynoise_"))
+        parsed = nested_dict_iter(data)
+        results.update({"greynoise_" + k: v for k, v in parsed.items()})
+        results.update(map_fields_to_cim(parsed))
 
         record.update(results)
 
@@ -435,6 +441,7 @@ def make_invalid_event(method, data, first_event=False, record=None):
             event = {}
 
         event.update(data)
+        event.update(map_fields_to_cim(data))
 
         event["source"] = "greynoise"
         event["sourcetype"] = "greynoise"
@@ -448,6 +455,8 @@ def make_invalid_event(method, data, first_event=False, record=None):
 
         for field, value in list(data.items()):
             event["greynoise_" + field] = value
+
+        event.update(map_fields_to_cim(data))
 
         record.update(event)
 

--- a/APP_FILES_ONLY/SA-GreyNoise/bin/fields.py
+++ b/APP_FILES_ONLY/SA-GreyNoise/bin/fields.py
@@ -223,29 +223,45 @@ TIMELINE_FIELDS = {
 }
 
 SIMILAR_FIELDS = {
-    'ip': None,
-    'actor': None,
-    'classification': None,
-    'first_seen': None,
-    'last_seen': None,
-    'asn': None,
-    'city': None,
-    'country': None,
-    'country_code': None,
-    'organization': None,
-    'similar_ips': None
+    "ip": None,
+    "actor": None,
+    "classification": None,
+    "first_seen": None,
+    "last_seen": None,
+    "asn": None,
+    "city": None,
+    "country": None,
+    "country_code": None,
+    "organization": None,
+    "similar_ips": None,
 }
 
 GREYNOISE_SIMILAR_FIELDS = {
-    'greynoise_ip': None,
-    'greynoise_actor': None,
-    'greynoise_classification': None,
-    'greynoise_first_seen': None,
-    'greynoise_last_seen': None,
-    'greynoise_asn': None,
-    'greynoise_city': None,
-    'greynoise_country': None,
-    'greynoise_country_code': None,
-    'greynoise_organization': None,
-    'greynoise_similar_ips': None
+    "greynoise_ip": None,
+    "greynoise_actor": None,
+    "greynoise_classification": None,
+    "greynoise_first_seen": None,
+    "greynoise_last_seen": None,
+    "greynoise_asn": None,
+    "greynoise_city": None,
+    "greynoise_country": None,
+    "greynoise_country_code": None,
+    "greynoise_organization": None,
+    "greynoise_similar_ips": None,
+}
+
+# Mapping between GreyNoise response fields and Splunk CIM fields
+CIM_FIELD_MAPPING = {
+    "ip": "src_ip",
+    "country": "src_country",
+    "country_code": "src_country_code",
+    "city": "src_city",
+    "region": "src_region",
+    "organization": "src_org",
+    "asn": "src_asn",
+    "actor": "threat_actor",
+    "tags": "signature",
+    "classification": "threat_category",
+    "vpn": "is_vpn",
+    "tor": "is_tor",
 }

--- a/APP_FILES_ONLY/SA-GreyNoise/bin/utility.py
+++ b/APP_FILES_ONLY/SA-GreyNoise/bin/utility.py
@@ -3,6 +3,7 @@ utility.py .
 
 Helper file containing useful methods
 """
+
 import collections
 import logging
 import traceback
@@ -232,6 +233,16 @@ def nested_dict_iter(nested, prefix=""):
         return parsed_dict
 
     return nester_method(api_response, prefix)
+
+
+def map_fields_to_cim(data):
+    """Return a dict with additional CIM field names mapped from GreyNoise fields."""
+    cim_data = {}
+    for key, value in data.items():
+        mapped = fields.CIM_FIELD_MAPPING.get(key)
+        if mapped:
+            cim_data[mapped] = value
+    return cim_data
 
 
 def validate_api_key(api_key, logger=None, proxy=None):


### PR DESCRIPTION
## Summary
- add `CIM_FIELD_MAPPING` in `fields.py`
- expose `map_fields_to_cim` helper in `utility.py`
- apply CIM mapping in event generation logic

## Testing
- `pre-commit run --files APP_FILES_ONLY/SA-GreyNoise/bin/event_generator.py APP_FILES_ONLY/SA-GreyNoise/bin/fields.py APP_FILES_ONLY/SA-GreyNoise/bin/utility.py`

------
https://chatgpt.com/codex/tasks/task_b_684ac88c2e58832d83ceaee6c169aa34